### PR TITLE
Upgrade gem dependencies

### DIFF
--- a/lib/redacted/version.rb
+++ b/lib/redacted/version.rb
@@ -1,3 +1,3 @@
 module Redacted
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/redacted.gemspec
+++ b/redacted.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties", ">= 3.2", "< 6.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rails", "~> 5.1"
+  spec.add_development_dependency "rails", ">= 4.1"
 end

--- a/redacted.gemspec
+++ b/redacted.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ffaker", "~> 2.3"
-  spec.add_dependency "nokogiri", "~> 1.6"
-  spec.add_dependency "railties", ">= 3.2", "< 5.0"
+  spec.add_dependency "ffaker", "~> 2.8.1"
+  spec.add_dependency "nokogiri", "~> 1.8.2"
+  spec.add_dependency "railties", ">= 3.2", "< 6.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rails", "~> 4.1"
+  spec.add_development_dependency "rails", "~> 5.1"
 end

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
@@ -29,6 +29,8 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   # config.action_mailer.delivery_method = :test
+
+  config.active_support.test_order = :sorted
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   # config.action_mailer.delivery_method = :test
 
-  config.active_support.test_order = :sorted
+  config.active_support.test_order = :random
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
This moves the gem towards Rails 5 compatibility
- Bumps the versions of all gems in the gemspec
- Gets rid of any deprecation warnings (config files in the dummy app)
- Bump's version number to 0.0.5